### PR TITLE
Make completed games outlined in gold

### DIFF
--- a/httpdocs/css/main.css
+++ b/httpdocs/css/main.css
@@ -262,6 +262,10 @@ div.beaten {
     border-color: #8bc53f;
 }
 
+div.completed {
+	border-color: #ffcc00;
+}
+
 div.blacklisted {
     border-color: #c80000;
 }

--- a/httpdocs/js/main.js
+++ b/httpdocs/js/main.js
@@ -203,6 +203,8 @@ function loadData(mode, gameid, value, search) {
                         $(this).achievementBarAnimate(data.gameachiev.gameid, data.gameachiev.percentage);
                     }
                 }
+				$("[data-achievper=100]").parents("div").addClass("completed");
+				$(".game_image").not("[data-achievper]").parents("div").filter(".beaten").addClass("completed");
             }
         }, 'json');
 }


### PR DESCRIPTION
Threw this together from googling jQuery. Works on both 100%'d games and 'beaten' games w/o achievements, the gold is from the pie chart. I did *not* refactor the chart to use the new class `.completed` instead of a query, or add filtering for completed games.